### PR TITLE
Compatibility, PE32+, and function labels

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,8 @@ There are several features in this plugin:
   * `Edit` -> `FakePDB` -> `Generate .PDB file` (or `Ctrl`+`Shift`+`4`)
   * get PDB file from the IDA database directory
 
+  The PDB can optionally include symbols for function labels: use `Generate .PDB file (with function labels)` (or `Ctrl`+`Shift`+`5`).
+
 ### 2. IDA database export to .json
   * Open target executable in IDA >= 7.0
   * `Edit` -> `FakePDB` -> `Dump info to .json` (or `Ctrl`+`Shift`+`1`)

--- a/src_ida/fakepdb/dumpinfo.py
+++ b/src_ida/fakepdb/dumpinfo.py
@@ -17,6 +17,9 @@
 import json
 import os.path
 
+if sys.version_info.major == 3:
+    from past.builtins import xrange
+
 import ida_auto
 import ida_bytes
 import ida_funcs

--- a/src_ida/fakepdb/dumpinfo.py
+++ b/src_ida/fakepdb/dumpinfo.py
@@ -14,8 +14,11 @@
    limitations under the License.
 """
 
+from __future__ import print_function
+
 import json
 import os.path
+import sys
 
 if sys.version_info.major == 3:
     from past.builtins import xrange
@@ -41,6 +44,8 @@ class InformationDumper():
     #
 
     def dump_info(self, filepath):
+        self._base = ida_nalt.get_imagebase()
+
         output = {
             'general'   : self.__process_general(), 
             'segments'  : self.__process_segments(),
@@ -121,37 +126,37 @@ class InformationDumper():
 
     def __process_segments(self):
         segments = list()
-        
+
         for n in xrange(ida_segment.get_segm_qty()):
             seg = ida_segment.getnseg(n)
             if seg:
                 segm = {
-                    'name'     : ida_segment.get_segm_name(seg),
-                    'start_ea' : seg.start_ea,
-                    'class'    : ida_segment.get_segm_class(seg),
-                    'selector' : seg.sel
+                    'name'      : ida_segment.get_segm_name(seg),
+                    'start_rva' : seg.start_ea - self._base,
+                    'class'     : ida_segment.get_segm_class(seg),
+                    'selector'  : seg.sel
                 }
                 
                 segments.append(segm)
 
         return segments
 
-    def __process_function_typeinfo(self, function):
+    def __process_function_typeinfo(self, info, func):
 
         tinfo = ida_typeinf.tinfo_t()
         func_type_data = ida_typeinf.func_type_data_t()
         if ida_pro.IDA_SDK_VERSION >= 740:
-            ida_typeinf.guess_tinfo(tinfo,function['start_ea'])
+            ida_typeinf.guess_tinfo(tinfo,func.start_ea)
         else:
-            ida_typeinf.guess_tinfo(function['start_ea'],tinfo)
+            ida_typeinf.guess_tinfo(func.start_ea,tinfo)
         tinfo.get_func_details(func_type_data)
 
         #calling convention
-        function['calling_convention'] = self.__describe_callingconvention(func_type_data.cc)
+        info['calling_convention'] = self.__describe_callingconvention(func_type_data.cc)
         func_type_data.rettype
         
         #return tpye
-        function['return_type'] = ida_typeinf.print_tinfo('', 0, 0, ida_typeinf.PRTYPE_1LINE, func_type_data.rettype, '', '')
+        info['return_type'] = ida_typeinf.print_tinfo('', 0, 0, ida_typeinf.PRTYPE_1LINE, func_type_data.rettype, '', '')
 
         #arguments
         arguments = list()
@@ -165,7 +170,7 @@ class InformationDumper():
             
             arguments.append(arginfo)
 
-        function['arguments'] = arguments
+        info['arguments'] = arguments
 
     def __process_functions(self):
         functions = list()
@@ -192,13 +197,17 @@ class InformationDumper():
             func_public = ida_name.is_public_name(start_ea)
 
             function = {
-                'start_ea'     : start_ea,
+                'start_rva'    : start_ea - self._base,
                 'name'         : func_name,
                 'is_public'    : func_public,
                 'is_autonamed' : func_autonamed
             }
 
-            self.__process_function_typeinfo(function)
+            # PE32/PE32+ only support binaries up to 2GB
+            if function['start_rva'] >= 2**32:
+                print('RVA out of range for function: ' + function['name'], file=sys.stderr)
+
+            self.__process_function_typeinfo(function, func)
             functions.append(function)
 
             func = ida_funcs.get_next_func(start_ea)
@@ -215,11 +224,15 @@ class InformationDumper():
                 continue
 
             name = {
-                'ea'        : ea,
+                'rva'       : ea - self._base,
                 'name'      : ida_name.get_nlist_name(i),
                 'is_public' : ida_name.is_public_name(ea),
                 'is_func'   : ida_funcs.get_func(ea) is not None
             }
+
+            # PE32/PE32+ only support binaries up to 2GB
+            if name['rva'] >= 2**32:
+                print('RVA out of range for name: ' + name['name'], file=sys.stderr)
 
             names.append(name)
 

--- a/src_ida/fakepdb/dumpinfo.py
+++ b/src_ida/fakepdb/dumpinfo.py
@@ -25,6 +25,7 @@ import ida_kernwin
 import ida_loader
 import ida_nalt
 import ida_name
+import ida_pro
 import ida_segment
 import ida_typeinf
 
@@ -136,8 +137,10 @@ class InformationDumper():
 
         tinfo = ida_typeinf.tinfo_t()
         func_type_data = ida_typeinf.func_type_data_t()
-        tinfo.get_named_type
-        ida_typeinf.guess_tinfo(function['start_ea'],tinfo)
+        if ida_pro.IDA_SDK_VERSION >= 740:
+            ida_typeinf.guess_tinfo(tinfo,function['start_ea'])
+        else:
+            ida_typeinf.guess_tinfo(function['start_ea'],tinfo)
         tinfo.get_func_details(func_type_data)
 
         #calling convention

--- a/src_ida/fakepdb/generation.py
+++ b/src_ida/fakepdb/generation.py
@@ -28,7 +28,7 @@ import ida_auto
 import ida_kernwin
 import ida_loader
 
-from dumpinfo import InformationDumper
+from .dumpinfo import InformationDumper
 
 class PdbGenerator:
 

--- a/src_ida/fakepdb/offsets.py
+++ b/src_ida/fakepdb/offsets.py
@@ -39,6 +39,10 @@ where:
 import json
 import os
 import traceback
+import sys
+
+if sys.version_info.major == 3:
+    from past.builtins import xrange
 
 import ida_idaapi
 import ida_kernwin

--- a/src_ida/fakepdb/signatures.py
+++ b/src_ida/fakepdb/signatures.py
@@ -14,6 +14,11 @@
    limitations under the License.
 """
 
+import sys
+
+if sys.version_info.major == 3:
+    from past.builtins import xrange
+
 import ida_bytes
 import ida_ida
 import ida_idaapi

--- a/src_pdbgen/CMakeLists.txt
+++ b/src_pdbgen/CMakeLists.txt
@@ -21,6 +21,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(LLVM REQUIRED CONFIG)
 
+if (MSVC)
+    # silence warnings from LLVM headers
+    add_compile_options(/experimental:external /external:anglebrackets /external:W0)
+    add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
+
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wextra)
+endif()
+
 add_library(pdbgen_common STATIC)
 target_sources(pdbgen_common PRIVATE
     guidhelper.h

--- a/src_pdbgen/idadb.cpp
+++ b/src_pdbgen/idadb.cpp
@@ -52,7 +52,7 @@ void IdaDb::load(std::filesystem::path& filepath)
         idaf.name = function["name"].get<std::string>();
         idaf.is_autonamed = function["is_autonamed"].get<bool>();
         idaf.is_public = function["is_public"].get<bool>();
-        idaf.start_ea = function["start_ea"].get<uint64_t>();
+        idaf.start_rva = function["start_rva"].get<uint32_t>();
 
         _functions.push_back(idaf);
     }
@@ -65,7 +65,7 @@ void IdaDb::load(std::filesystem::path& filepath)
         idan.name = name["name"].get<std::string>();
         idan.is_func = name["is_func"].get<bool>();
         idan.is_public = name["is_public"].get<bool>();
-        idan.ea = name["ea"].get<uint64_t>();
+        idan.rva = name["rva"].get<uint32_t>();
         
         _names.push_back(idan);
     }

--- a/src_pdbgen/idadb.cpp
+++ b/src_pdbgen/idadb.cpp
@@ -52,7 +52,7 @@ void IdaDb::load(std::filesystem::path& filepath)
         idaf.name = function["name"].get<std::string>();
         idaf.is_autonamed = function["is_autonamed"].get<bool>();
         idaf.is_public = function["is_public"].get<bool>();
-        idaf.start_ea = function["start_ea"].get<uint32_t>();
+        idaf.start_ea = function["start_ea"].get<uint64_t>();
 
         _functions.push_back(idaf);
     }
@@ -65,7 +65,7 @@ void IdaDb::load(std::filesystem::path& filepath)
         idan.name = name["name"].get<std::string>();
         idan.is_func = name["is_func"].get<bool>();
         idan.is_public = name["is_public"].get<bool>();
-        idan.ea = name["ea"].get<uint32_t>();
+        idan.ea = name["ea"].get<uint64_t>();
         
         _names.push_back(idan);
     }

--- a/src_pdbgen/idadb.cpp
+++ b/src_pdbgen/idadb.cpp
@@ -20,6 +20,28 @@
 
 #include <fstream>
 
+void from_json(const nlohmann::json& j, IdaLabel& l) {
+    j.at("offset").get_to(l.offset);
+    j.at("name").get_to(l.name);
+    j.at("is_public").get_to(l.is_public);
+    j.at("is_autonamed").get_to(l.is_autonamed);
+}
+
+void from_json(const nlohmann::json& j, IdaFunction& f) {
+    j.at("start_rva").get_to(f.start_rva);
+    j.at("name").get_to(f.name);
+    j.at("is_public").get_to(f.is_public);
+    j.at("is_autonamed").get_to(f.is_autonamed);
+    j.at("labels").get_to(f.labels);
+}
+
+void from_json(const nlohmann::json& j, IdaName& n) {
+    j.at("rva").get_to(n.rva);
+    j.at("name").get_to(n.name);
+    j.at("is_public").get_to(n.is_public);
+    j.at("is_func").get_to(n.is_func);
+}
+
 IdaDb::IdaDb(std::filesystem::path& filepath)
 {
     load(filepath);
@@ -45,28 +67,15 @@ void IdaDb::load(std::filesystem::path& filepath)
     istream >> json;
 
     //Function
-    _functions.clear();
-    auto& functions = json["functions"];
-    for (auto& function : functions) {
-        IdaFunction idaf{};
-        idaf.name = function["name"].get<std::string>();
-        idaf.is_autonamed = function["is_autonamed"].get<bool>();
-        idaf.is_public = function["is_public"].get<bool>();
-        idaf.start_rva = function["start_rva"].get<uint32_t>();
+    _functions = json.at("functions").get<std::vector<IdaFunction>>();
 
-        _functions.push_back(idaf);
+    //Labels
+    for (auto &idaFunc : _functions) {
+        for (auto &idaLabel : idaFunc.labels) {
+            idaLabel.name = idaFunc.name + ":::" + idaLabel.name;
+        }
     }
 
     //Names
-    _names.clear();
-    auto& names = json["names"];
-    for (auto& name : names) {
-        IdaName idan{};
-        idan.name = name["name"].get<std::string>();
-        idan.is_func = name["is_func"].get<bool>();
-        idan.is_public = name["is_public"].get<bool>();
-        idan.rva = name["rva"].get<uint32_t>();
-        
-        _names.push_back(idan);
-    }
+    _names = json.at("names").get<std::vector<IdaName>>();
 }

--- a/src_pdbgen/idadb.h
+++ b/src_pdbgen/idadb.h
@@ -22,13 +22,13 @@
 
 struct IdaFunction {
     std::string name;
-    uint64_t start_ea;
+    uint32_t start_rva;
     bool is_public;
     bool is_autonamed;
 };
 
 struct IdaName {
-    uint64_t ea;
+    uint32_t rva;
     std::string name;
     bool is_public;
     bool is_func;

--- a/src_pdbgen/idadb.h
+++ b/src_pdbgen/idadb.h
@@ -20,11 +20,19 @@
 #include <filesystem>
 #include <vector>
 
+struct IdaLabel {
+    uint32_t offset;
+    std::string name;
+    bool is_public;
+    bool is_autonamed;
+};
+
 struct IdaFunction {
     std::string name;
     uint32_t start_rva;
     bool is_public;
     bool is_autonamed;
+    std::vector<IdaLabel> labels;
 };
 
 struct IdaName {

--- a/src_pdbgen/idadb.h
+++ b/src_pdbgen/idadb.h
@@ -22,13 +22,13 @@
 
 struct IdaFunction {
     std::string name;
-    uint32_t start_ea;
+    uint64_t start_ea;
     bool is_public;
     bool is_autonamed;
 };
 
 struct IdaName {
-    uint32_t ea;
+    uint64_t ea;
     std::string name;
     bool is_public;
     bool is_func;

--- a/src_pdbgen/main.cpp
+++ b/src_pdbgen/main.cpp
@@ -27,7 +27,7 @@ int main_usage(){
     std::cout << "PDB generator" << std::endl << "Usage:" << std::endl 
     << "* pdbgen symserv_exe <exe filepath> -- returns EXE folder name for symbol server" << std::endl
     << "* pdbgen symserv_pdb <exe filepath> -- returns PDB folder name for symbol server" << std::endl
-    << "* pdbgen generate <exe filepath> <json filepath> <output file> -- generate PDB file for given file" << std::endl;
+    << "* pdbgen generate [-l] <exe filepath> <json filepath> <output file> -- generate PDB file for given file" << std::endl;
     return 0;
 }
 
@@ -63,9 +63,15 @@ int main_symserv_pdb(int argc, char* argv[]){
 
 
 int main_generate(int argc, char* argv[]) {
-    std::filesystem::path path_exe  = argv[2];
-    std::filesystem::path path_json = argv[3];
-    std::filesystem::path path_out  = argv[4];
+    bool with_labels = false;
+    size_t arg_exe = 2;
+    if (argc > 5 && std::string(argv[2]) == "-l") {
+        arg_exe++;
+        with_labels = true;
+    }
+    std::filesystem::path path_exe  = argv[arg_exe];
+    std::filesystem::path path_json = argv[arg_exe+1];
+    std::filesystem::path path_out  = argv[arg_exe+2];
 
     if (!std::filesystem::exists(path_exe)) {
 		std::cerr << ".exe file does not exists";
@@ -79,7 +85,7 @@ int main_generate(int argc, char* argv[]) {
 
     PeFile pefile(path_exe);
     IdaDb ida_db(path_json);
-    PdbCreator creator(pefile);
+    PdbCreator creator(pefile, with_labels);
 
     creator.Initialize();
     creator.ImportIDA(ida_db);

--- a/src_pdbgen/pdbcreator.cpp
+++ b/src_pdbgen/pdbcreator.cpp
@@ -104,7 +104,8 @@ void PdbCreator::ImportIDA(IdaDb& ida_db)
 bool PdbCreator::Commit(std::filesystem::path& path)
 {
 	std::filesystem::create_directories(path.parent_path());
-    if (_pdbBuilder.commit(path.string(), &_pdbBuilder.getInfoBuilder().getGuid())) {
+    auto guid = _pdbBuilder.getInfoBuilder().getGuid();
+    if (_pdbBuilder.commit(path.string(), &guid)) {
         return false;
     }
 
@@ -188,8 +189,8 @@ llvm::pdb::BulkPublic PdbCreator::createPublicSymbol(IdaFunction& idaFunc)
     public_sym.Name = idaFunc.name.c_str();
     public_sym.NameLen = idaFunc.name.size();
     public_sym.setFlags(llvm::codeview::PublicSymFlags::Function);
-    public_sym.Segment = _pefile.GetSectionIndexForEA(idaFunc.start_ea);
-    public_sym.Offset = _pefile.GetSectionOffsetForEA(idaFunc.start_ea);
+    public_sym.Segment = _pefile.GetSectionIndexForRVA(idaFunc.start_rva);
+    public_sym.Offset = _pefile.GetSectionOffsetForRVA(idaFunc.start_rva);
 
     return public_sym;
 }
@@ -200,8 +201,8 @@ llvm::pdb::BulkPublic PdbCreator::createPublicSymbol(IdaName& idaName)
     public_sym.Name = idaName.name.c_str();
     public_sym.NameLen = idaName.name.size();
     public_sym.setFlags(llvm::codeview::PublicSymFlags::None);
-    public_sym.Segment = _pefile.GetSectionIndexForEA(idaName.ea);
-    public_sym.Offset = _pefile.GetSectionOffsetForEA(idaName.ea);
+    public_sym.Segment = _pefile.GetSectionIndexForRVA(idaName.rva);
+    public_sym.Offset = _pefile.GetSectionOffsetForRVA(idaName.rva);
 
     return public_sym;
 }

--- a/src_pdbgen/pdbcreator.cpp
+++ b/src_pdbgen/pdbcreator.cpp
@@ -32,7 +32,7 @@ template <typename R, class FuncTy> void parallelSort(R&& Range, FuncTy Fn) {
     llvm::parallelSort(std::begin(Range), std::end(Range), Fn);
 }
 
-PdbCreator::PdbCreator(PeFile& pefile) : _pefile(pefile),  _pdbBuilder(_allocator)
+PdbCreator::PdbCreator(PeFile& pefile, bool withLabels) : _pefile(pefile), _withLabels(withLabels), _pdbBuilder(_allocator)
 {
 }
 
@@ -127,12 +127,14 @@ void PdbCreator::processGSI(IdaDb& ida_db)
     for (auto& ida_func : ida_db.Functions()) {
         Publics.push_back(createPublicSymbol(ida_func));
 
-        for (const auto& ida_label : ida_func.labels) {
-            if (ida_label.is_autonamed) {
-                continue;
-            }
+        if (_withLabels) {
+            for (const auto& ida_label : ida_func.labels) {
+                if (ida_label.is_autonamed) {
+                    continue;
+                }
 
-            Publics.push_back(createPublicSymbol(ida_label, ida_func));
+                Publics.push_back(createPublicSymbol(ida_label, ida_func));
+            }
         }
     }
 

--- a/src_pdbgen/pdbcreator.cpp
+++ b/src_pdbgen/pdbcreator.cpp
@@ -188,9 +188,9 @@ llvm::pdb::BulkPublic PdbCreator::createPublicSymbol(IdaFunction& idaFunc)
     public_sym.Name = idaFunc.name.c_str();
     public_sym.NameLen = idaFunc.name.size();
     public_sym.setFlags(llvm::codeview::PublicSymFlags::Function);
-    public_sym.Segment = _pefile.GetSectionIndexForRVA(idaFunc.start_ea);
-    public_sym.Offset = _pefile.GetSectionOffsetForRVA(idaFunc.start_ea);
-   
+    public_sym.Segment = _pefile.GetSectionIndexForEA(idaFunc.start_ea);
+    public_sym.Offset = _pefile.GetSectionOffsetForEA(idaFunc.start_ea);
+
     return public_sym;
 }
 
@@ -200,8 +200,8 @@ llvm::pdb::BulkPublic PdbCreator::createPublicSymbol(IdaName& idaName)
     public_sym.Name = idaName.name.c_str();
     public_sym.NameLen = idaName.name.size();
     public_sym.setFlags(llvm::codeview::PublicSymFlags::None);
-    public_sym.Segment = _pefile.GetSectionIndexForRVA(idaName.ea);
-    public_sym.Offset = _pefile.GetSectionOffsetForRVA(idaName.ea);
+    public_sym.Segment = _pefile.GetSectionIndexForEA(idaName.ea);
+    public_sym.Offset = _pefile.GetSectionOffsetForEA(idaName.ea);
 
     return public_sym;
 }

--- a/src_pdbgen/pdbcreator.cpp
+++ b/src_pdbgen/pdbcreator.cpp
@@ -187,8 +187,8 @@ llvm::pdb::BulkPublic PdbCreator::createPublicSymbol(IdaFunction& idaFunc)
     llvm::pdb::BulkPublic public_sym;
     public_sym.Name = idaFunc.name.c_str();
     public_sym.NameLen = idaFunc.name.size();
-    public_sym.Flags = static_cast<uint16_t>(llvm::codeview::PublicSymFlags::Function);
-    public_sym.U.Segment = _pefile.GetSectionIndexForRVA(idaFunc.start_ea);
+    public_sym.setFlags(llvm::codeview::PublicSymFlags::Function);
+    public_sym.Segment = _pefile.GetSectionIndexForRVA(idaFunc.start_ea);
     public_sym.Offset = _pefile.GetSectionOffsetForRVA(idaFunc.start_ea);
    
     return public_sym;
@@ -199,8 +199,8 @@ llvm::pdb::BulkPublic PdbCreator::createPublicSymbol(IdaName& idaName)
     llvm::pdb::BulkPublic public_sym;
     public_sym.Name = idaName.name.c_str();
     public_sym.NameLen = idaName.name.size();
-    public_sym.Flags = static_cast<uint16_t>(llvm::codeview::PublicSymFlags::None);
-    public_sym.U.Segment = _pefile.GetSectionIndexForRVA(idaName.ea);
+    public_sym.setFlags(llvm::codeview::PublicSymFlags::None);
+    public_sym.Segment = _pefile.GetSectionIndexForRVA(idaName.ea);
     public_sym.Offset = _pefile.GetSectionOffsetForRVA(idaName.ea);
 
     return public_sym;

--- a/src_pdbgen/pdbcreator.h
+++ b/src_pdbgen/pdbcreator.h
@@ -53,6 +53,7 @@ private:
     void processSymbols();
 
     llvm::pdb::BulkPublic createPublicSymbol(IdaFunction& idaFunc);
+    llvm::pdb::BulkPublic createPublicSymbol(const IdaLabel& idaLabel, const IdaFunction& idaFunc);
     llvm::pdb::BulkPublic createPublicSymbol(IdaName& idaName);
 
     PeFile& _pefile;

--- a/src_pdbgen/pdbcreator.h
+++ b/src_pdbgen/pdbcreator.h
@@ -33,7 +33,7 @@
 class PdbCreator {
 public:
 
-    PdbCreator(PeFile& peFile);
+    PdbCreator(PeFile& peFile, bool withLabels);
 
     bool Initialize();
 
@@ -57,6 +57,8 @@ private:
     llvm::pdb::BulkPublic createPublicSymbol(IdaName& idaName);
 
     PeFile& _pefile;
+
+    bool _withLabels;
 
     llvm::BumpPtrAllocator _allocator;
     llvm::pdb::PDBFileBuilder _pdbBuilder;

--- a/src_pdbgen/pefile.h
+++ b/src_pdbgen/pefile.h
@@ -39,9 +39,9 @@ public:
 
     llvm::ArrayRef<llvm::object::coff_section> GetSectionHeaders();
 
-    uint16_t GetSectionIndexForRVA(uint32_t RVA);
+    uint16_t GetSectionIndexForEA(uint64_t EA);
 
-    uint32_t GetSectionOffsetForRVA(uint32_t RVA);
+    uint32_t GetSectionOffsetForEA(uint64_t EA);
 
 	uint32_t GetTimestamp();
 

--- a/src_pdbgen/pefile.h
+++ b/src_pdbgen/pefile.h
@@ -39,13 +39,13 @@ public:
 
     llvm::ArrayRef<llvm::object::coff_section> GetSectionHeaders();
 
-    uint16_t GetSectionIndexForEA(uint64_t EA);
+    uint16_t GetSectionIndexForRVA(uint32_t RVA);
 
-    uint32_t GetSectionOffsetForEA(uint64_t EA);
+    uint32_t GetSectionOffsetForRVA(uint32_t RVA);
 
-	uint32_t GetTimestamp();
+    uint32_t GetTimestamp();
 
-	uint32_t GetImageSize();
+    uint32_t GetImageSize();
 
     llvm::COFF::MachineTypes GetMachine();
 


### PR DESCRIPTION
This PR brings several changes that kind of build upon each other, but that I can likely split upon request. :)

In commit order, the changes are:

* compatibility fix with latest LLVM master (actually llvm/llvm-project@b7402edce315, there were more recent changes to PDB-related code but I don't think they affect pdbgen)
* compatibility with IDA 7.4+
* compatibility with Python 3, since IDA 7.4+ is moving towards Python 3 (but the changes should not break Python 2 compatibility)
* PE32+ support (basically it turns a bunch of `uint32_t` into `uint64_t` and things seem to just work)
* support for rebased IDBs by exporting RVAs instead of EAs to JSON
* optional export of function labels in the generated PDB

As a side note with regards to LLVM compatibility, in the future wouldn't it be easier to settle on a tagged LLVM release instead of always chasing after master's breaking changes?

Feel free to suggest changes to the PR as you think is needed.
And by the way, thanks a lot for this awesome tool!