### PR TITLE
Fix PDB generation for DLLs (#12)

### DIFF
--- a/src_ida/fakepdb/dumpinfo.py
+++ b/src_ida/fakepdb/dumpinfo.py
@@ -275,7 +275,7 @@ class __fakepdb_dumpinfo_actionhandler(ida_kernwin.action_handler_t):
 
         filepath = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
         pre, _ = os.path.splitext(filepath)
-        filepath = pre + ".exe.json"
+        filepath = pre + ".json"
 
         dumper = InformationDumper()
         print('FakePDB/dumpinfo:')

--- a/src_ida/fakepdb/generation.py
+++ b/src_ida/fakepdb/generation.py
@@ -27,6 +27,7 @@ import traceback
 import ida_auto
 import ida_kernwin
 import ida_loader
+import ida_nalt
 
 from .dumpinfo import InformationDumper
 
@@ -77,10 +78,15 @@ class __fakepdb_pdbgeneration_actionhandler(ida_kernwin.action_handler_t):
 
         #get exe location
         filepath_ida = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+        filepath_input = ida_nalt.get_input_file_path()
+
+        filename = os.path.basename(filepath_input) # app.exe / app.dll
+
         pre, _ = os.path.splitext(filepath_ida)
         pre, _ = os.path.splitext(pre)
-        filepath_exe = pre + ".exe"
-        filepath_json = pre + ".exe.json"
+
+        filepath_exe = filepath_input
+        filepath_json = pre + ".json"
         filepath_pdb = pre + ".pdb"
 
         #generate json       


### PR DESCRIPTION
Fixes issue #12.
The behavioral difference is that the JSON filename only has the base part of the database name, without adding ".exe" or ".dll" for simplicity. That's also on par with pdb naming scheme. Hopefully that's not a big issue, but could probably be fixed by a few more lines of code if needed.
This should fix the case in which the original file was in a different dir than the IDA database.