### PR TITLE
Fixed name being null causing issues

### DIFF
--- a/src_plugins/ida/fakepdb/dumpinfo.py
+++ b/src_plugins/ida/fakepdb/dumpinfo.py
@@ -816,6 +816,9 @@ class DumpInfo():
             if ida_funcs.get_func(ea) is not None:
                 continue
 
+            if ida_name.get_nlist_name(i) is None:
+                continue
+
             name = {
                 'rva'            : ea - self._base,
                 'name'           : ida_name.get_nlist_name(i),


### PR DESCRIPTION
For some ungodly I have some null names and addresses in an IDB and the dumper is pulling null causing issues when generating PDB files, this change fixes this so if a name is null we don't add it to the names list
![image](https://user-images.githubusercontent.com/6237734/235628980-0bd7466e-6d2a-4378-9d95-415158411f33.png)