### PR TITLE
Check before creating directory & remove redundant create

### DIFF
--- a/src_cpp/src_pdb/commands/command_pdb_generate.h
+++ b/src_cpp/src_pdb/commands/command_pdb_generate.h
@@ -62,8 +62,6 @@ namespace FakePDB::Commands {
             PDB::PdbCreator creator;
             creator.Initialize(ida_db, path_exe, with_labels);
 
-            std::filesystem::create_directories(path_out.parent_path());
-
             creator.Commit(path_out);
 
             return 0;

--- a/src_cpp/src_pdb/pdb/pdb_creator.cpp
+++ b/src_cpp/src_pdb/pdb/pdb_creator.cpp
@@ -122,7 +122,9 @@ namespace FakePDB::PDB {
     }
 
     bool PdbCreator::Commit(std::filesystem::path &path) {
-        std::filesystem::create_directories(path.parent_path());
+        std::filesystem::path dir = path.parent_path();
+        if (!dir.empty() && !std::filesystem::exists(dir))
+            std::filesystem::create_directories(dir);
         auto guid = _pdbBuilder.getInfoBuilder().getGuid();
         if (_pdbBuilder.commit(path.string(), &guid)) {
             return false;


### PR DESCRIPTION
If output directory is not provided, skip checking or creating it