### PR TITLE
Scope of sections shouldn't be limited to processSections

### DIFF
--- a/src_cpp/src_pdb/pdb/pdb_creator.cpp
+++ b/src_cpp/src_pdb/pdb/pdb_creator.cpp
@@ -181,19 +181,19 @@ namespace FakePDB::PDB {
 
     bool PdbCreator::processSections(Data::DB& ida_db) {
         auto &DbiBuilder = _pdbBuilder.getDbiBuilder();
+        _sections.clear();
 
         // Add Section Map stream.
-        std::vector<llvm::object::coff_section> sections;
         for (const auto& segment : ida_db.Segments()) {
-            sections.push_back(segment.toLLVM());
+            _sections.push_back(segment.toLLVM());
         }
 
-        DbiBuilder.createSectionMap(sections);
+        DbiBuilder.createSectionMap(_sections);
 
         // Add COFF section header stream.
         auto sectionsTable = llvm::ArrayRef<uint8_t>(
-            reinterpret_cast<const uint8_t*>(sections.data()),
-            sections.size()*sizeof(llvm::object::coff_section));
+            reinterpret_cast<const uint8_t*>(_sections.data()),
+            _sections.size()*sizeof(llvm::object::coff_section));
         
         if (DbiBuilder.addDbgStream(llvm::pdb::DbgHeaderType::SectionHdr, sectionsTable)) {
             return false;

--- a/src_cpp/src_pdb/pdb/pdb_creator.h
+++ b/src_cpp/src_pdb/pdb/pdb_creator.h
@@ -50,5 +50,6 @@ namespace FakePDB::PDB {
 
         llvm::BumpPtrAllocator _allocator;
         llvm::pdb::PDBFileBuilder _pdbBuilder;
+        std::vector<llvm::object::coff_section> _sections;
     };
 }


### PR DESCRIPTION
The scope of sections variable should be outside the method processSections.
It is used later when committing output file.